### PR TITLE
Change video pattern

### DIFF
--- a/lib/fragmentor/parser/content_splitter.ex
+++ b/lib/fragmentor/parser/content_splitter.ex
@@ -4,8 +4,8 @@ defmodule Fragmentor.Parser.HtmlParser.ContentSplitter do
   whenever there is a code or video tag
   """
   @delimiter "*****"
-  @starting_pattern ~r/(<pre|<iframe)/
-  @ending_pattern ~r/(<\/pre>|<\/iframe>)/
+  @starting_pattern ~r/(<pre|<a href)/
+  @ending_pattern ~r/(<\/pre>|<\/a>)/
 
   @spec split(String.t()) :: list(String.t())
   def split(html_content) do

--- a/lib/fragmentor/parser/fragment_mapper.ex
+++ b/lib/fragmentor/parser/fragment_mapper.ex
@@ -8,7 +8,7 @@ defmodule Fragmentor.Parser.HtmlParser.FragmentMapper do
   @code_starting "<pre"
   @code_pattern ~r/<pre><code\s+class="(.+)?">([\s\S]+)+?<\/code><\/pre>/
 
-  @video_starting "<iframe"
+  @video_starting "<a href"
   @video_pattern ~r/http(?:s)?:\/\/(?:www\.)?.+(youtube|vimeo).+\/(?:embed|video)\/(.+?)(?:"|\?)/
 
   @spec to_struct(String.t()) :: %{

--- a/test/support/fixtures/html/multiple_fragments.html
+++ b/test/support/fixtures/html/multiple_fragments.html
@@ -6,8 +6,8 @@
         caracteres, onde cada posição desse array
         contém um caractere.</em>
 </p>
-<iframe src="https://player.vimeo.com/video/677241568?h=fa10b08e7c" width="640" height="360" frameborder="0"
-    allow="autoplay; fullscreen; picture-in-picture"></iframe>
+<a href="https://player.vimeo.com/video/677241568?h=fa10b08e7c" width="640" height="360" frameborder="0"
+    allow="autoplay; fullscreen; picture-in-picture"></a>
 <p>Veja mais um exemplo:</p>
 <p>Vamos começar utilizando <code class="inline">minhaString.indexOf(meuCaracter)</code> para que a função retorne o
     índice, ou seja, a posição da primeira ocorrência do caractere na string dada. Confira como fazer isso no código


### PR DESCRIPTION
The as_html!/2 function is responsible for converting a markdown to html. Converting a markdown video, `![](www.youtube.com)` results in `<a href="www.youtube.com"></a>` not an <iframe />. This PR aims to discuss and fix the video pattern.