### PR TITLE
[FIX] [LEARN-5855] Altera delimitador de separador de fragmentos

### DIFF
--- a/lib/fragmentor/parser/content_splitter.ex
+++ b/lib/fragmentor/parser/content_splitter.ex
@@ -3,7 +3,7 @@ defmodule Fragmentor.Parser.HtmlParser.ContentSplitter do
   Module responsible for splitting html texts into a list
   whenever there is a code or video tag
   """
-  @delimiter "*****"
+  @delimiter "(353d9062\-7872\-4d64\-91b7\-f3959a0bf49d)"
   @starting_pattern ~r/(<pre|<iframe)/
   @ending_pattern ~r/(<\/pre>|<\/iframe>)/
 


### PR DESCRIPTION
**Contexto**
Foi encontrado um [erro](https://betrybe.slack.com/archives/C033B5S7EMN/p1657809859751269), em que um objeto de conteúdo não pode ser separado em fragmentos pois continua a sequência de caracteres `*****`.
Esse problema era causado pois essa sequência era usada como separadora de conteúdo.

Esse `pr` corrige esse problema alterando o separador de conteúdo para um `uuid`. Essa abordagem busca evitar que futuras colisões possam acontecer.