### PR TITLE
[LEARN-5103] Adiciona processamento para adicionar target blank em links

### DIFF
--- a/lib/fragmentor/processor.ex
+++ b/lib/fragmentor/processor.ex
@@ -16,8 +16,9 @@ defmodule Fragmentor.Processor do
 
   def to_html(markdown, options) do
     with {:ok, html_doc, _} <- Earmark.as_html(markdown, options),
-         html_sanitized <- Utils.remove_hr_inner_class(html_doc) do
-      {:ok, html_sanitized}
+         html_sanitized <- Utils.remove_hr_inner_class(html_doc),
+         html_with_target_blank_links <- Utils.add_target_blank_on_links(html_sanitized) do
+      {:ok, html_with_target_blank_links}
     else
       {:error, _html_doc, error_messages} -> {:error, error_messages}
     end
@@ -32,6 +33,7 @@ defmodule Fragmentor.Processor do
     markdown
     |> Earmark.as_html!(options)
     |> Utils.remove_hr_inner_class()
+    |> Utils.add_target_blank_on_links()
   end
 
   ## ToDo Adicionar tratamento de erro aqui

--- a/lib/fragmentor/utils.ex
+++ b/lib/fragmentor/utils.ex
@@ -12,6 +12,14 @@ defmodule Fragmentor.Utils do
   end
 
   @doc """
+  Add html target="_blank" on links being parsed
+  """
+  @spec add_target_blank_on_links(binary()) :: binary()
+  def add_target_blank_on_links(html_content) do
+    String.replace(html_content, "<a", "<a target=\"_blank\"")
+  end
+
+  @doc """
   Removes html hr tag class values
   """
   @spec remove_hr_inner_class(binary()) :: binary()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Fragmentor.MixProject do
   def project do
     [
       app: :fragmentor,
-      version: "0.1.2",
+      version: "0.2.0",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Fragmentor.MixProject do
   def project do
     [
       app: :fragmentor,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/fragmentor/utils_test.exs
+++ b/test/fragmentor/utils_test.exs
@@ -1,0 +1,13 @@
+defmodule Fragmentor.UtilsTest do
+  @moduledoc false
+  use ExUnit.Case
+
+  alias Fragmentor.Utils
+
+  describe "add_target_blank_on_links/1" do
+    test "ensure links have target=\"blank\"" do
+      html_content = "<h1>Title<h1><a href=\"www.google.com\">"
+      assert Utils.add_target_blank_on_links(html_content) =~ "target=\"_blank\""
+    end
+  end
+end


### PR DESCRIPTION
[Tarefa no Jira
](https://trybe.atlassian.net/jira/software/c/projects/LEARN/boards/138?modal=detail&selectedIssue=LEARN-5103)**Contexto**
Time de currículo pediu para que os links dos conteúdos sejam abertos em uma nova aba. Isso seria para melhorar a navegeção e não tirar a pessoa estudante do conteúdo.

No parser antigo (course) existia um shortcode de link externo. 

Para o novo parser, utilizado pelo serviço de conteúdo, vamos inicialmente injetar o atributo target="_blank" em todos os href