### PR TITLE
[LEARN-5079] Documentar lib de fragmentos

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ There are two available functions and their trailing bang counterparts options a
 - `Fragmentor.to_html(markdown, options \\ [])`
 - `Fragmentor.to_html!(markdown, options \\ [])`
 - `Fragmentor.to_fragments(markdown, options \\ [])`
-- `Fragmentor.to_html(markdown, options \\ [])`
+- `Fragmentor.to_fragments!(markdown, options \\ [])`
 
 The `to_html/2` function takes a `markdown` text, convert it to `html` using `earmark` and apply some post processings such making every link target blank.
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,138 @@
 # Fragmentor
 
-**TODO: Add description**
+Fragmentor helps to render `markdown` on web browsers.
+It takes a raw markdown text as input, translate it to `html` using  [earmark](https://github.com/pragdave/earmark) and then create chunks of html code objects.
+
+## Chunk types
+
+Currently there are three types of chunk:
+
+### Code chunk
+
+A markdown code text taken as input:
+
+~~~
+ ```elixir
+ my_map = %{name: foo, age: 23}
+ ```
+~~~
+
+Produces the following object output:
+
+```elixir
+  %Fragmentor.Fragment.Code{
+    fragment_type: "code",
+    language: "elixir",
+    content: "my_map = %{name: foo, age: 23}"
+  }
+```
+
+### Video chunk
+
+An html video iframe placed in markdown
+
+```html
+  <iframe src="https://player.vimeo.com/video/675564253?h=588f932258" width="640" height="360" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+```
+
+Produces the following object output:
+
+```elixir
+  %Fragmentor.Fragment.Video{
+    fragment_type: "video",
+    provider: "vimeo",
+    url: "https://player.vimeo.com/video/675564253?",
+    video_id: "675564253"
+  }
+````
+
+### Html content chunk
+
+Other general markdown texts
+
+```markdown
+  hello it`s an markdown
+```
+
+Produces the following object output:
+
+```elixir
+ Fragmentor.Fragment.Html{
+    fragment_type: "html",
+    content: "hello it`s a markdown",
+  }
+```
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `fragmentor` to your list of dependencies in `mix.exs`:
+To install Fragmentor add it to your list of dependencies in `mix.ex`.
 
 ```elixir
 def deps do
   [
-    {:fragmentor, "~> 0.1.0"}
+    {:fragmentor, "~> 0.2.0"}
   ]
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/fragmentor](https://hexdocs.pm/fragmentor).
+The auto generated docs can be found at [https://hexdocs.pm/fragmentor](https://hexdocs.pm/fragmentor).
+
+## How to use Fragmentor
+
+There are two available functions and their bang counterparts options according the elixir common practices:
+
+- `Fragmentor.to_html(markdown, options \\ [])`
+- `Fragmentor.to_html!(markdown, options \\ [])`
+- `Fragmentor.to_fragments(markdown, options \\ [])`
+- `Fragmentor.to_html(markdown, options \\ [])`
+
+The `to_html/2` function takes a `markdown` text, convert it to `html` using `earmark` and apply some post processings such making every link target blank.
+
+Usage:
+
+```elixir
+  markdown = """
+    ```java
+      public class HelloWorld {
+        public static void main(String[] args) {
+          System.out.println("Primeira Linha");
+          System.out.println("Segunda Linha");
+        }
+      }
+    ```
+  """
+  Fragmentor.to_html!(markdown)
+```
+
+```elixir
+ "<pre><code class=\"java\">public class HelloWorld {\npublic static void main(String[] args) {\nSystem.out.println(&quot;Primeira Linha&quot;);\nSystem.out.println(&quot;Segunda Linha&quot;);\n}"
+```
+
+The `to_framents/2` function takes a `markdown` text, convert it using the `to_html/2` function and then split it up into fragments.
+
+Usage:
+
+```elixir
+  markdown = """
+    ```java
+      public class HelloWorld {
+        public static void main(String[] args) {
+          System.out.println("Primeira Linha");
+          System.out.println("Segunda Linha");
+        }
+      }
+    ```
+  """
+  Fragmentor.to_fragments!(markdown)
+```
+
+```elixir
+  %Fragmentor.Fragment.Code{
+    fragment_type: "code",
+    language: "elixir",
+    content: "public class HelloWorld {\npublic static void main(String[] args) {\nSystem.out.println(\"Primeira Linha\");\nSystem.out.println(\"Segunda Linha\");\n}\n}"
+  }
+```
 
 ## Copyright and License
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The auto generated docs can be found at [https://hexdocs.pm/fragmentor](https://
 
 ## How to use Fragmentor
 
-There are two available functions and their bang counterparts options according the elixir common practices:
+There are two available functions and their trailing bang counterparts options according the [elixir common practices](https://hexdocs.pm/elixir/main/naming-conventions.html):
 
 - `Fragmentor.to_html(markdown, options \\ [])`
 - `Fragmentor.to_html!(markdown, options \\ [])`


### PR DESCRIPTION
**Contexto**
Criamos uma lib para converter conteúdo de `markdown` para `html` e de `html` para o formato de fragmento que o `frontend` utiliza.

**O que esse pr faz?**
Atualiza a o `readme` do projeto com descrição e modo de uso.